### PR TITLE
Set WORKDIR to /opt/openshift/src

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,6 @@ EXPOSE 8080
 ENV RACK_ENV production
 ENV RAILS_ENV production
 COPY . /opt/openshift/src/
+WORKDIR /opt/openshift/src
 RUN scl enable ror40 "bundle install"
 CMD ["scl", "enable", "ror40", "./run.sh"]


### PR DESCRIPTION
Without this, the Dockerfile tries to use (and update) nonexistent /Gemfile and /Gemfile.lock (and it does not have the necessary rights to create /Gemfile.lock); likewise (./run.sh) out of / won’t work when the code is in /opt/openshift/src/.

AFAICS the code could never have worked like this, so perhaps I am missing something.